### PR TITLE
Do not render None in columns

### DIFF
--- a/src/bootlace/table/base.py
+++ b/src/bootlace/table/base.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 import attrs
 from dominate import tags
 from dominate.dom_tag import dom_tag
+from dominate.util import text
 
 from bootlace.icon import Icon
 from bootlace.util import as_tag
@@ -55,8 +56,15 @@ class ColumnBase(ABC):
     def attribute(self) -> str:
         """The attribute name for the column."""
         if self.name is None:
-            raise ValueError("column must be named in Table or attribute= parameter must be provided")
+            raise ValueError("column must be named in Table or name= parameter must be provided")
         return self.name
+
+    def contents(self, value: Any) -> Any:
+        """Return the contents of the cell for the column, using an HTML comment if the attribute value is None."""
+        contents = getattr(value, self.attribute)
+        if contents is None:
+            return tags.comment(f"no value for {self.name}")
+        return text(str(contents))
 
     @abstractmethod
     def cell(self, value: Any) -> dom_tag:

--- a/src/bootlace/table/columns.py
+++ b/src/bootlace/table/columns.py
@@ -23,7 +23,7 @@ class Column(ColumnBase):
 
     def cell(self, value: Any) -> dom_tag:
         """Return the cell for the column as an HTML tag."""
-        return text(str(getattr(value, self.attribute)))
+        return self.contents(value)
 
 
 @attrs.define
@@ -40,7 +40,7 @@ class EditColumn(ColumnBase):
     def cell(self, value: Any) -> tags.html_tag:
         """Return the cell for the column as an HTML tag."""
         id = getattr(value, "id", None)
-        return self.a(getattr(value, self.attribute), href=url_for(self.endpoint, id=id))
+        return self.a(self.contents(value), href=url_for(self.endpoint, id=id))
 
 
 @attrs.define

--- a/tests/table/test_columns.py
+++ b/tests/table/test_columns.py
@@ -8,6 +8,7 @@ from bootlace.extension import Bootlace
 from bootlace.icon import Icon
 from bootlace.table.base import Heading
 from bootlace.table.columns import CheckColumn
+from bootlace.table.columns import Column
 from bootlace.table.columns import Datetime
 from bootlace.table.columns import EditColumn
 from bootlace.testing import assert_same_html
@@ -27,6 +28,7 @@ class Item:
     editor: str = "editor"
     check: bool = True
     id: int = 1
+    missing: str | None = None
 
     when: dt.datetime = dt.datetime(2021, 1, 1, 12, 18, 5)
 
@@ -106,7 +108,7 @@ def test_datetime_column(app: Flask) -> None:
     assert_same_html(expected, str(td))
 
 
-def test_datetime_format(app: Flask) -> None:
+def test_datetime_format() -> None:
 
     col = Datetime(heading="Date", name="when", format="%Y-%m-%d")
 
@@ -115,3 +117,12 @@ def test_datetime_format(app: Flask) -> None:
     expected = "<td>2021-01-01</td>"
 
     assert_same_html(expected, str(td))
+
+
+def test_regular_column_missing() -> None:
+
+    col = Column(heading="Something", name="missing")
+
+    td = col.cell(Item())
+    expected = "<!--no value for missing-->"
+    assert str(td) == expected


### PR DESCRIPTION
Column items which are None are rendered as an HTML comment, and will appear in the UI as a blank.